### PR TITLE
Fixed bug with Rm calculation.

### DIFF
--- a/itctools/itctools.py
+++ b/itctools/itctools.py
@@ -1,5 +1,6 @@
 import itertools
 from pint import UnitRegistry
+import numpy
 
 ureg = UnitRegistry()
 Quantity = ureg.Quantity
@@ -16,3 +17,7 @@ def permutation_with_replacement(n, seq):
         options.append(p)
     return options
 
+@ureg.wraps(ureg.dimensionless, ureg.dimensionless, strict=False)
+def compute_rm(c):
+    rm = 6.4 / numpy.power(c, 0.2) + 13 / c
+    return rm

--- a/itctools/procedures.py
+++ b/itctools/procedures.py
@@ -140,6 +140,9 @@ class ITCHeuristicExperiment(ITCExperiment):
 
         rm = compute_rm(c)
 
+        if rm < 1.0:
+            raise ValueError("Value of Rm should be greater than 1: %s" % rm)
+
         if not approx:
             # Use exact equation [X]_s = R_m * [M]_0 (1- exp(-mv/V0))^-1
             self.syringe_concentration = rm * self.cell_concentration * \

--- a/itctools/procedures.py
+++ b/itctools/procedures.py
@@ -1,5 +1,5 @@
 import numpy
-from .itctools import ureg
+from .itctools import ureg, compute_rm
 import openpyxl  # Excel spreadsheet I/O (for Auto iTC-200)
 from openpyxl import Workbook
 from distutils.version import StrictVersion  # For version testing
@@ -136,9 +136,9 @@ class ITCHeuristicExperiment(ITCExperiment):
 
         # c = [M]_0 * Ka
         c = self.cell_concentration * Ka
-
         # R_m = 6.4/c^0.2 + 13/c
-        rm = 6.4 / numpy.power(c, 0.2) + 13 / c
+
+        rm = compute_rm(c)
 
         if not approx:
             # Use exact equation [X]_s = R_m * [M]_0 (1- exp(-mv/V0))^-1
@@ -207,15 +207,13 @@ class ITCHeuristicExperiment(ITCExperiment):
             # syringe is scaled by same factor
             if self.syringe_concentration is not None:
                 self.syringe_concentration *= cfactor
-            #recompute dilution factor
+            # recompute dilution factor
             self.cell_dilution_factor = self.cell_concentration / self.cell_source.concentration
 
         except AttributeError as err:
             # Labware has no concentration (buffer)
             print("WARNING, cell cannot be rescaled. This may still be desired if cell is not buffer or water.")
             print("Full error details: \n %s" % err)
-
-
 
         # recompute dilution factor
         if self.syringe_concentration is not None:

--- a/tests/test_itctools.py
+++ b/tests/test_itctools.py
@@ -4,7 +4,7 @@ from itctools import itctools as itc
 
 class TestPermutation(unittest.TestCase):
 
-    """Validation of the itctools submodule."""
+    """Validation of the itctools.permutation_without_replacement function."""
 
     def _check_uniques(self, n, seq):
         """A set can't hold multiple copies of the same value.
@@ -14,7 +14,7 @@ class TestPermutation(unittest.TestCase):
         self.assertEqual(len(compositions), len(set(compositions)))
 
     def test_permutation_with_replacement_uniques(self):
-        """Make sure that permutation_with_replacement only generates unique sequences (when given unique inputs)."""
+        """Ensure that permutation_with_replacement only generates unique sequences (when given unique inputs)."""
         seq = ['So test', 'Much robust', 'Very unit', 'Wow']
         for x in range(0, 7):
             self._check_uniques(x, seq)
@@ -27,19 +27,19 @@ class TestPermutation(unittest.TestCase):
             self.assertEqual(len(comp), n)
 
     def test_permutation_with_replacement_length(self):
-        """Make sure that permutation_with_replacement generates correct length."""
+        """Ensure that permutation_with_replacement generates correct length."""
         seq = ['Did', 'you', 'mean', '"dog"?']
         for x in range(0, 7):
             self._check_length(x, seq)
 
     def test_ureg(self):
-        """Make sure that the units are working"""
+        """Ensure that the units are working"""
         quantity = itc.Quantity(140.0, 'micromolar')
         self.assertAlmostEqual(quantity / itc.ureg.standard_concentration, 1.4E-4, places=7)
 
 
 class TestRm(unittest.TestCase):
-    """Validation of the Rm calculations"""
+    """Validation of t"""
 
     def test_Rm_over_1(self):
         """Ensure that Rm return values greater than 1 with strange pint units."""

--- a/tests/test_itctools.py
+++ b/tests/test_itctools.py
@@ -39,7 +39,7 @@ class TestPermutation(unittest.TestCase):
 
 
 class TestRm(unittest.TestCase):
-    """Validation of t"""
+    """Validation of the itctools.compute_rm function"""
 
     def test_Rm_over_1(self):
         """Ensure that Rm return values greater than 1 with strange pint units."""

--- a/tests/test_itctools.py
+++ b/tests/test_itctools.py
@@ -2,7 +2,7 @@ import unittest
 from itctools import itctools as itc
 
 
-class TestITC(unittest.TestCase):
+class TestPermutation(unittest.TestCase):
 
     """Validation of the itctools submodule."""
 
@@ -36,6 +36,17 @@ class TestITC(unittest.TestCase):
         """Make sure that the units are working"""
         quantity = itc.Quantity(140.0, 'micromolar')
         self.assertAlmostEqual(quantity / itc.ureg.standard_concentration, 1.4E-4, places=7)
+
+
+class TestRm(unittest.TestCase):
+    """Validation of the Rm calculations"""
+
+    def test_Rm_over_1(self):
+        """Ensure that Rm return values greater than 1 with strange pint units."""
+        for value in [1000, 1000000., 5000000, 10000000]:
+            c = itc.ureg.Quantity(value, 'millimole/mole')
+            rm = itc.compute_rm(c)
+            self.assertGreaterEqual(itc.compute_rm(c), 1.0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Error was that pint did not handle dimensionless unit correctly for numpy function. Leads to weird "millmole/mole" units that cause factor 1000 errors in calculations.

Fixes #40.